### PR TITLE
launch scripts override GAZEBO_MASTER_URI

### DIFF
--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -21,11 +21,17 @@ then
 fi
 
 client_final="-g `catkin_find --first-only libgazebo_ros_paths_plugin.$EXT`"
+
+setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+
+# source setup.sh, but keep local modifications to GAZEBO_MASTER_URI
 desired_master_uri="$GAZEBO_MASTER_URI"
+. $setup_path/setup.sh
+if [ "$desired_master_uri" = "" ]; then
+	desired_master_uri="$GAZEBO_MASTER_URI"
+fi
 
 # Combine the commands
-setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
-. $setup_path/setup.sh 
 GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final & 
 GAZEBO_MASTER_URI="$desired_master_uri" gzclient $client_final
 

--- a/gazebo_ros/scripts/gazebo
+++ b/gazebo_ros/scripts/gazebo
@@ -21,12 +21,13 @@ then
 fi
 
 client_final="-g `catkin_find --first-only libgazebo_ros_paths_plugin.$EXT`"
+desired_master_uri="$GAZEBO_MASTER_URI"
 
 # Combine the commands
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
 . $setup_path/setup.sh 
-gzserver $final & 
-gzclient $client_final
+GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final & 
+GAZEBO_MASTER_URI="$desired_master_uri" gzclient $client_final
 
 # Kill the server
 kill -s $SIGNAL $!

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -12,6 +12,8 @@ then
     final="$final -g `catkin_find --first-only libgazebo_ros_paths_plugin.$EXT`"
 fi
 
+desired_master_uri="$GAZEBO_MASTER_URI"
+
 # Combine the commands
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
-. $setup_path/setup.sh && gzclient $final
+. $setup_path/setup.sh && GAZEBO_MASTER_URI="$desired_master_uri" gzclient $final

--- a/gazebo_ros/scripts/gzclient
+++ b/gazebo_ros/scripts/gzclient
@@ -12,8 +12,14 @@ then
     final="$final -g `catkin_find --first-only libgazebo_ros_paths_plugin.$EXT`"
 fi
 
+setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
+
+# source setup.sh, but keep local modifications to GAZEBO_MASTER_URI
 desired_master_uri="$GAZEBO_MASTER_URI"
+. $setup_path/setup.sh
+if [ "$desired_master_uri" = "" ]; then
+	desired_master_uri="$GAZEBO_MASTER_URI"
+fi
 
 # Combine the commands
-setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
-. $setup_path/setup.sh && GAZEBO_MASTER_URI="$desired_master_uri" gzclient $final
+GAZEBO_MASTER_URI="$desired_master_uri" gzclient $final

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -18,7 +18,13 @@ then
     final="$final -s `catkin_find --first-only libgazebo_ros_api_plugin.$EXT`"
 fi
 
-desired_master_uri="$GAZEBO_MASTER_URI"
-
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
-. $setup_path/setup.sh && GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final
+
+# source setup.sh, but keep local modifications to GAZEBO_MASTER_URI
+desired_master_uri="$GAZEBO_MASTER_URI"
+. $setup_path/setup.sh
+if [ "$desired_master_uri" = "" ]; then
+	desired_master_uri="$GAZEBO_MASTER_URI"
+fi
+
+GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final

--- a/gazebo_ros/scripts/gzserver
+++ b/gazebo_ros/scripts/gzserver
@@ -18,5 +18,7 @@ then
     final="$final -s `catkin_find --first-only libgazebo_ros_api_plugin.$EXT`"
 fi
 
+desired_master_uri="$GAZEBO_MASTER_URI"
+
 setup_path=$(pkg-config --variable=prefix gazebo)/share/gazebo/
-. $setup_path/setup.sh && gzserver $final
+. $setup_path/setup.sh && GAZEBO_MASTER_URI="$desired_master_uri" gzserver $final


### PR DESCRIPTION
GAZEBO_MASTER_URI is always the one written in `setup.sh`, even if a different value is set in the user's environment. 

I consider it counter-intuitive, if you e.g. run `GAZEBO_MASTER_URI=http://myserver:11345 rosrun gazebo_ros gzserver`, that the server is still started with the default URI.
